### PR TITLE
fix: remove extension scanner false positives

### DIFF
--- a/Classes/Configuration/IconSetConfiguration.php
+++ b/Classes/Configuration/IconSetConfiguration.php
@@ -54,6 +54,7 @@ class IconSetConfiguration extends AbstractBaseConfiguration
     public function getIconByType(string $iconType): Icon
     {
         $iconConfiguration = $this->getIconConfigurationByType($iconType);
+        // @extensionScannerIgnoreLine
         return $iconConfiguration->getIcon();
     }
 

--- a/Tests/Unit/Configuration/IconConfigurationTest.php
+++ b/Tests/Unit/Configuration/IconConfigurationTest.php
@@ -7,6 +7,9 @@ use ITplusX\FlexiblePages\Tests\Fixtures\PageTypesConfigurationFixture;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
+/**
+ * @extensionScannerIgnoreFile
+ */
 class IconConfigurationTest extends TestCase
 {
     /**


### PR DESCRIPTION
Due to the nature of the [Extension Scanner](https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/ExtensionScanner/Index.html#extension-scanner) the method getIcon() was detected as deprecated. But since this method is a method shipped with this extension the calls should be ignored by the Extension Scanner (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ApiOverview/ExtensionScanner/Index.html#extension-authors)