### PR TITLE
ci: add workflow to refresh the TER API access token

### DIFF
--- a/.github/workflows/refreshToken.yml
+++ b/.github/workflows/refreshToken.yml
@@ -1,0 +1,13 @@
+name: refreshToken
+
+on:
+  schedule:
+    # Every six months
+    - cron: '0 0 1 */6 *'
+
+jobs:
+  refreshToken:
+    uses: itplusx/github-workflows/.github/workflows/refresh-typo3-api-access-token.yml@main
+    secrets:
+      access-token: ${{ secrets.TYPO3_API_REFRESH_TOKEN }}
+


### PR DESCRIPTION
Since the token required for [publishing the extension via API](https://github.com/itplusx/flexible_pages/pull/14) is only valid for max 1 year it has to be refreshed periodically.

see: https://github.com/itplusx/github-workflows/blob/main/.github/workflows/refresh-typo3-api-access-token.yml

