### PR TITLE
feat: load all yaml config files regardless the name

### DIFF
--- a/Classes/Bootstrap/BootCompletedEventListener.php
+++ b/Classes/Bootstrap/BootCompletedEventListener.php
@@ -50,7 +50,7 @@ class BootCompletedEventListener
             });
 
             foreach ($localExtensions as $extension) {
-                $configPaths[] = $extension->getPackagePath() . 'Configuration/Yaml/' . ExtensionConfigurationUtility::EXTKEY;
+                $configPaths[] = $extension->getPackagePath() . 'Configuration/{Yaml,YAML}/' . ExtensionConfigurationUtility::EXTKEY;
             }
 
             // Custom configuration path from extension configuration

--- a/Classes/Registry/PageTypesRegistration.php
+++ b/Classes/Registry/PageTypesRegistration.php
@@ -24,7 +24,7 @@ class PageTypesRegistration implements SingletonInterface
      * @internal
      * @var string
      */
-    protected $configFileName = 'config.yaml';
+    protected $configFileName = '*.{yaml,yml}';
 
     /**
      * @param array additionalConfigPaths
@@ -72,13 +72,13 @@ class PageTypesRegistration implements SingletonInterface
     {
         $pageTypeConfiguration = [];
 
-        $finder = (new Finder())->files()->depth(0)->name($this->configFileName);
+        $finder = (new Finder())->files()->name($this->configFileName);
         $hasConfigurationFiles = false;
         foreach (array_filter($this->configPaths) as $configPath) {
             try {
-                $finder->in($configPath . '/*');
+                $finder->in($configPath);
             } catch (\InvalidArgumentException $e) {
-                // Directory $configPath does not exist yet
+                // Directory $configPath does not exist
                 continue;
             }
             $hasConfigurationFiles = true;

--- a/README.md
+++ b/README.md
@@ -73,9 +73,12 @@ As with the site configuration of the TYPO3 core it is also possible to add YAML
 Example:
 ```
 config/
-└── flexible_pages/      --> Required to be named exactly like this.
-    └── myNewPageType/   --> Identifier of your pageType. Not used by the registering process yet.
-        └── config.yaml  --> Required to be named exactly like this.
+└── flexible_pages/
+    └── myNewPageType.yaml
+    └── myOtherPageType.yaml
+    └── Articles
+        └── blogArticle.yaml
+        └── newsArticle.yaml
 ```
 
 
@@ -84,13 +87,15 @@ It is also possible for every third-party extension to use `flexible_pages` as b
 
 Example:
 ```
-typo3conf/
-└── ext/
-    └── your_extensionkey/
-        └── Configuration/
-            └── flexible_pages/      --> Required to be named exactly like this.
-                └── myNewPageType/   --> Identifier of your pageType. Not used by the registering process yet.
-                    └── config.yaml  --> Required to be named exactly like this.
+your_extensionkey/
+└── Configuration/
+    └── Yaml
+        └── flexible_pages/
+            └── myNewPageType.yaml
+            └── myOtherPageType.yaml
+            └── Articles
+                └── blogArticle.yaml
+                └── newsArticle.yaml
 ```
 
 


### PR DESCRIPTION
With this change developers can place their config files more freely within the defined configuration paths.