### PR TITLE
feat!: flatten pageType registration configuration structure

### DIFF
--- a/Classes/Registry/PageTypesRegistration.php
+++ b/Classes/Registry/PageTypesRegistration.php
@@ -43,23 +43,32 @@ class PageTypesRegistration implements SingletonInterface
     {
         $pageTypes = $this->getAllPageTypeConfigurationFromFiles();
 
-        foreach ($pageTypes as $dokType => $pageTypeConfiguration) {
-            self::registerPageType(
-                $dokType,
-                $pageTypeConfiguration['configuration']
-            );
+        foreach ($pageTypes as $pageTypeConfiguration) {
+            self::registerPageType(...$pageTypeConfiguration);
         }
     }
 
     /**
      * Register a single pageType
      *
-     * @param int $dokType The dokType to register the new pageType with
-     * @param array $configuration The configuration of the pageType
+     * @param int $dokType
+     * @param string $label
+     * @param array $iconSet
+     * @param bool $isDraggableInNewPageDragArea
+     * @return void
      */
-    public static function registerPageType(int $dokType, array $configuration): void
+    public static function registerPageType(
+        int $dokType,
+        string $label,
+        array $iconSet,
+        bool $isDraggableInNewPageDragArea = false
+    ): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][ExtensionConfigurationUtility::EXTKEY]['pageTypes'][$dokType] = $configuration;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF'][ExtensionConfigurationUtility::EXTKEY]['pageTypes'][$dokType] = [
+            'label' => $label,
+            'iconSet' => $iconSet,
+            'isDraggableInNewPageDragArea' => $isDraggableInNewPageDragArea
+        ];
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -106,39 +106,36 @@ Beside the first two pre-defined directory paths it is also possible to define a
 #### 2.1.4 YAML File Example
 ```
 dokType: 87
-configuration:
-  label: 'My Custom pageType'
-  iconSet:
-    defaultIcon:
-      source: 'EXT:your_ext/Resources/Public/Icons/apps-pagetree-mycustompagetype.svg'
-    hideInMenuIcon:
-      identifier: 'apps-pagetree-page-frontend-user-hideinmenu'
-    rootPageIcon:
-      source: 'EXT:your_ext/Resources/Public/Icons/apps-pagetree-mycustompagetype-root.svg'
-  isDraggableInNewPageDragArea: true
+label: 'My Custom pageType'
+iconSet:
+  defaultIcon:
+    source: 'EXT:your_ext/Resources/Public/Icons/apps-pagetree-mycustompagetype.svg'
+  hideInMenuIcon:
+    identifier: 'apps-pagetree-page-frontend-user-hideinmenu'
+  rootPageIcon:
+    source: 'EXT:your_ext/Resources/Public/Icons/apps-pagetree-mycustompagetype-root.svg'
+isDraggableInNewPageDragArea: true
 
 ```
 
 
 ### 2.2 Using ext_localconf.php
-```
+```php
 \ITplusX\FlexiblePages\Registry\PageTypesRegistration::registerPageType(
-    87,
-    [
-        'label' => 'My Custom pageType',
-        'iconSet' => [
-            \ITplusX\FlexiblePages\Configuration\IconSetConfiguration::ICON_TYPE_DEFAULT => [
-                'source' => 'EXT:your_ext/Resources/Public/Icons/apps-pagetree-mycustompagetype.svg',
-            ],
-            \ITplusX\FlexiblePages\Configuration\IconSetConfiguration::ICON_TYPE_HIDE_IN_MENU => [
-                'identifier' => 'apps-pagetree-page-frontend-user-hideinmenu',
-            ]
-            \ITplusX\FlexiblePages\Configuration\IconSetConfiguration::ICON_TYPE_ROOT_PAGE => [
-                'source' => 'EXT:your_ext/Resources/Public/Icons/apps-pagetree-mycustompagetype-root.svg',
-            ]
-        ],
-        'isDraggableInNewPageDragArea' => true
+  87
+  'My Custom pageType',
+  [
+    \ITplusX\FlexiblePages\Configuration\IconSetConfiguration::ICON_TYPE_DEFAULT => [
+        'source' => 'EXT:your_ext/Resources/Public/Icons/apps-pagetree-mycustompagetype.svg',
+    ],
+    \ITplusX\FlexiblePages\Configuration\IconSetConfiguration::ICON_TYPE_HIDE_IN_MENU => [
+        'identifier' => 'apps-pagetree-page-frontend-user-hideinmenu',
     ]
+    \ITplusX\FlexiblePages\Configuration\IconSetConfiguration::ICON_TYPE_ROOT_PAGE => [
+        'source' => 'EXT:your_ext/Resources/Public/Icons/apps-pagetree-mycustompagetype-root.svg',
+    ]
+  ],
+  'isDraggableInNewPageDragArea' => true
 );
 ```
 
@@ -146,21 +143,15 @@ configuration:
 ### 2.3 Configuration
 
 #### 2.3.1 Registration parameters
-| Parameter     | Type  | Mandatory | Description                                                                                        |
-|---------------|-------|-----------|----------------------------------------------------------------------------------------------------|
-| dokType       | int   | ✓         | The dokType to register the new pageType with                                                      |
-| configuration | array | ✓         | The configuration of the pageType (see: [Configuration parameters](#232-configuration-parameters)) |
-
-
-#### 2.3.2 Configuration parameters
 | Parameter                    | Type   | Mandatory | Description                                                                                            |
 |------------------------------|--------|-----------|--------------------------------------------------------------------------------------------------------|
+| dokType                      | int    | ✓         | The dokType to register the new pageType with                                                          |
 | label                        | string | ✓         | The label of the new pageType                                                                          |
-| iconSet                      | array  | ✓         | The iconSet array of the newPageType. (see: [iconSet configuration parameters](#233-icons-parameters)) |
+| iconSet                      | array  | ✓         | The iconSet array of the newPageType. (see: [iconSet configuration parameters](#232-icons-parameters)) |
 | isDraggableInNewPageDragArea | bool   |           | Defines if the new pageType is draggable from above the page tree. (Default: false)                    |
 
 
-#### 2.3.3 Icons parameters
+#### 2.3.2 Icons parameters
 | Parameter      | Type  | Mandatory | Description                                                  | Possible values                                                                                          |
 |----------------|-------|-----------|--------------------------------------------------------------|----------------------------------------------------------------------------------------------------------|
 | defaultIcon    | array | ✓         | The default icon of the page.                                | - `'source' => '/path/to/file.png'`(EXT: is allowed)<br> - `'identifier' => 'already-registered-identifier'` |


### PR DESCRIPTION
With this change we are getting rid of the `configure` config sub-level. I didn't really understand why we separated the config like this in the first place.

old:
```yaml
dokType: 87
configuration:
  label: 'My Custom pageType'
  iconSet:
    defaultIcon:
      source: 'EXT:your_ext/Resources/Public/Icons/apps-pagetree-mycustompagetype.svg'
    hideInMenuIcon:
      identifier: 'apps-pagetree-page-frontend-user-hideinmenu'
    rootPageIcon:
      source: 'EXT:your_ext/Resources/Public/Icons/apps-pagetree-mycustompagetype-root.svg'
  isDraggableInNewPageDragArea: true
```

new:
```yaml
dokType: 87
label: 'My Custom pageType'
iconSet:
  defaultIcon:
    source: 'EXT:your_ext/Resources/Public/Icons/apps-pagetree-mycustompagetype.svg'
  hideInMenuIcon:
    identifier: 'apps-pagetree-page-frontend-user-hideinmenu'
  rootPageIcon:
    source: 'EXT:your_ext/Resources/Public/Icons/apps-pagetree-mycustompagetype-root.svg'
isDraggableInNewPageDragArea: true
```

In perspective of making the default icon optional (#26) the minimal pageType setup would be as simple as:

```yaml
dokType: 87
label: 'My Custom pageType'
```

instead of:
```yaml
dokType: 87
configuration:
  label: 'My Custom pageType'
```