### PR TITLE
fix: include pageType TypoScript after headless TypoScript

### DIFF
--- a/Classes/Bootstrap/BootCompletedEventListener.php
+++ b/Classes/Bootstrap/BootCompletedEventListener.php
@@ -126,7 +126,8 @@ class BootCompletedEventListener
                         'page.10.fields.type {
                             ' . $pageType->getDokType() .' = TEXT
                             ' . $pageType->getDokType() .'.value = ' . $pageType->getLabel() .'
-                        }'
+                        }',
+                        'defaultContentRendering'
                     );
                 }
             }


### PR DESCRIPTION
This ensures that the added TypoScript for each pageType will always be included after the headless TypoScript